### PR TITLE
Remove undefined symbol

### DIFF
--- a/src/bfd-manager.cxx
+++ b/src/bfd-manager.cxx
@@ -107,7 +107,7 @@ typedef struct symbol_information_st
 	bfd_boolean found;
 } symbol_information_t;
 
-static void find_address_in_section (bfd *abfd, asection *section, PTR data)
+static void find_address_in_section (bfd *abfd, asection *section, void *data)
 {
 	/* TODO fix this */
 #define HAVE_BFD_GET_SECTION_SIZE 1


### PR DESCRIPTION
PTR is not supported by gcc since 2022-05-10 given the changelog: [](https://github.com/gcc-mirror/gcc/blob/master/include/ChangeLog)

Theis seems to be an old symbol used for compatibility between non ANSI-C and ANSI-C codes. I'm not sure it is still relevant to make the distinction; if the library was to be compiled with an old enough compiler that would require the "untyped pointer" to be declared as `char *`, there would be many more issues elsewhere in the code.