### PR TITLE
Check if allocators are configured

### DIFF
--- a/src/allocator-memkind-hbwmalloc.cxx
+++ b/src/allocator-memkind-hbwmalloc.cxx
@@ -204,6 +204,8 @@ void AllocatorMemkindHBWMalloc::configure (const char *config)
 		               " Size <NUM> MBytes\n");
 		exit (1);
 	}
+
+	_is_ready = true;
 }
 
 const char * AllocatorMemkindHBWMalloc::name (void) const

--- a/src/allocator-memkind-pmem.cxx
+++ b/src/allocator-memkind-pmem.cxx
@@ -315,6 +315,8 @@ void AllocatorMemkindPMEM::configure (const char *config)
 		VERBOSE_MSG(0, "Error! Incorrect number of PMEM nodes for PMEM allocator (%d). Should be equal to number of NUMA nodes (%d).\n", nnodes, _num_NUMA_nodes);
 		exit (-1);
 	}
+
+	_is_ready = true;
 }
 
 const char * AllocatorMemkindPMEM::name (void) const

--- a/src/allocator-posix.cxx
+++ b/src/allocator-posix.cxx
@@ -199,6 +199,8 @@ void AllocatorPOSIX::configure (const char *config)
 		               " Size <NUM> MBytes\n");
 		exit (1);
 	}
+
+	_is_ready = true;
 }
 
 const char * AllocatorPOSIX::name (void) const

--- a/src/allocator.hxx
+++ b/src/allocator.hxx
@@ -40,6 +40,7 @@ class Allocator
 	size_t _size;
 	bool _used;
 	Allocator * _fallback;
+	bool _is_ready;
 	
 	public:
 	Allocator (allocation_functions_t &);
@@ -69,7 +70,9 @@ class Allocator
 
 	virtual void *memcpy (void *dest, const void *src, size_t n) = 0;
 
-	virtual void   configure (const char *) = 0;
+	virtual void configure (const char *) = 0;
+	virtual bool is_ready (void) const { return _is_ready; };
+
 	void size (size_t s) { _size = s; _has_size = s > 0; };
 	size_t size (void) const { return _size; };
 	bool has_size (void) const { return _has_size; };

--- a/src/code-locations.cxx
+++ b/src/code-locations.cxx
@@ -257,7 +257,7 @@ bool CodeLocations::process_raw_location (char *location_txt, location_t * locat
 	location->allocator = _allocators->get (allocator);
 	if (location->allocator == nullptr)
 	{
-		VERBOSE_MSG (0, "Error! Given allocator '%s' does not exist in given memory definitions file.\n", allocator);
+		VERBOSE_MSG (0, "Error! Reference to unsupported allocator '%s' while processing raw location '%s'.\n", allocator, location_txt);
 		return false;
 	}
 
@@ -442,8 +442,9 @@ bool CodeLocations::readfile (const char *f, const char *fallback_allocator_name
 			}
 
 			// Process source location and see if it is correctly processed (and not ignored).
+			bool is_valid = false;
 			if (options.sourceFrames() &&
-			    process_source_location (p_current, &_locations[_nlocations], fallback_allocator_name))
+				process_source_location (p_current, &_locations[_nlocations], fallback_allocator_name))
 			{
 				clean_source_location (&_locations[_nlocations]);
 				if (_locations[_nlocations].nframes > options.maxDepth())
@@ -458,16 +459,25 @@ bool CodeLocations::readfile (const char *f, const char *fallback_allocator_name
 				memset (&_locations[_nlocations].stats, 0, sizeof(location_stats_t));
 				_locations[_nlocations].id = _nlocations+1;
 				_nlocations++;
+				is_valid = true;
 			}
 			// Process raw location and see if it is correctly processed (and not ignored).
 			if (!options.sourceFrames() &&
-			     process_raw_location (p_current, &_locations[_nlocations], fallback_allocator_name))
+				 process_raw_location (p_current, &_locations[_nlocations], fallback_allocator_name))
 			{
 				_min_nframes = MIN(_min_nframes, _locations[_nlocations].nframes);
 				_max_nframes = MAX(_max_nframes, _locations[_nlocations].nframes);
 				memset (&_locations[_nlocations].stats, 0, sizeof(location_stats_t));
 				_locations[_nlocations].id = _nlocations+1;
 				_nlocations++;
+				is_valid = true;
+			}
+
+			if (is_valid) {
+				if (! _locations[_nlocations-1].allocator->is_ready()) {
+					VERBOSE_MSG(0, "The allocator \"%s\" is not available. Check if its parameters in the configuration file are correct.\n", _locations[_nlocations-1].allocator->name());
+					exit (-1);
+				}
 			}
 		}
 		else

--- a/src/malloc-interposer.cxx
+++ b/src/malloc-interposer.cxx
@@ -853,6 +853,12 @@ void malloc_interposer_start (void)
 			_exit (0);
 		}
 	}
+
+	if (! fallback->is_ready()) {
+		VERBOSE_MSG(0, "The fallback allocator '%s' is not ready. Check if its parameters in the configuration file are correct. Exiting!\n", fallback->name());
+		_exit (0);
+	}
+
 	VERBOSE_MSG(0, "Fallback allocator set to '%s'\n", fallback->name());
 
 	if (fallback->has_size())
@@ -891,6 +897,11 @@ void malloc_interposer_start (void)
 			if (!fallback_smallAllocation)
 			{
 				VERBOSE_MSG(0, "Did not find allocator \"%s\" to be used as fallback allocator for small allocations. Exiting!\n", env);
+				_exit (0);
+			}
+
+			if (! fallback_smallAllocation->is_ready()) {
+				VERBOSE_MSG(0, "The fallback allocator for small allocations '%s' is not ready. Check if its parameters in the configuration file are correct.\n", fallback_smallAllocation->name());
 				_exit (0);
 			}
 		}


### PR DESCRIPTION
This change adds a way to check if the allocators have been initialized (configured) in the configuration file, and report an error if a location is assigned to an uninitialized allocator. It also checks the fallback allocators.