### PR TITLE
Check that the library is properly loaded when intercepting dlopen

### DIFF
--- a/src/malloc-interposer.cxx
+++ b/src/malloc-interposer.cxx
@@ -217,19 +217,24 @@ int pthread_create (
 
 void* dlopen(const char *file, int mode)
 {
-    static void* (*o_dlopen) ( const char *file, int mode )=0;
-    o_dlopen = (void*(*)(const char *file, int mode)) dlsym(RTLD_NEXT,"dlopen");
-    void* res = (*o_dlopen)( file, mode );
-    char *env = getenv(TOOL_LOCATIONS_FILE);
+	static void* (*o_dlopen) ( const char *file, int mode )=0;
+	o_dlopen = (void*(*)(const char *file, int mode)) dlsym(RTLD_NEXT,"dlopen");
+	void* res = (*o_dlopen)( file, mode );
+	char *env = getenv(TOOL_LOCATIONS_FILE);
 
-    if (file != NULL){
-       if (env != nullptr){
-                  VERBOSE_MSG(0, "New library '%s' was loaded. Updating code locations.\n", file);
-                  codelocations->readfile(env, fallback->name());
-        }
-    }
+	if (LIKELY(malloc_interposer_started))
+	{
+		if (file != NULL)
+		{
+			if (env != nullptr)
+			{
+				VERBOSE_MSG(0, "New library '%s' was loaded. Updating code locations.\n", file);
+				codelocations->readfile(env, fallback->name());
+			}
+		}
+	}
 
-    return res;
+	return res;
 }
 
 void * malloc (size_t size)


### PR DESCRIPTION
In the interception of dlopen, the library may not be fully loaded when the interception happens. For example, the loading of extra allocator may require to dlopen an external library.
In case of an dlopen happening mid-initialisation of flexmalloc, a segmentation fault will occur as codelocation is still NULL, and so is the fallback allocator.

By checking whether the library is loaded or not, we only postpone the update of code location to its original call, later in the initialisation process. The code locations are still updated otherwise.