### PR TITLE
Ease the use of application requiring flexmalloc through GDB

### DIFF
--- a/scripts/flexmalloc.sh
+++ b/scripts/flexmalloc.sh
@@ -53,7 +53,6 @@ if [[ "${mpi_rank}" == "0" || "${mpi_rank}" == "" ]] ; then
 set environment FLEXMALLOC_DEFINITIONS ${1}
 set environment FLEXMALLOC_LOCATIONS ${2}
 set exec-wrapper env '${set_LD_PRELOAD}'
-break main
 EOF
 		case "${FLEXMALLOC_GDB}" in
 			1|enabled|yes)

--- a/scripts/flexmalloc.sh
+++ b/scripts/flexmalloc.sh
@@ -34,6 +34,11 @@ if [[ -z "${mpi_rank}" ]]; then
 	mpi_rank="${PMI_RANK}"
 fi
 
+if test -z "${TMPDIR}"
+then
+	TMPDIR=/tmp
+fi
+
 # # If MPI rank is 0 or non MPI-execution, set minimum verbosity
 if [[ "${mpi_rank}" == "0" || "${mpi_rank}" == "" ]] ; then
 	# Set verbose level 1 if no verbosity requested in rank 0
@@ -43,7 +48,7 @@ if [[ "${mpi_rank}" == "0" || "${mpi_rank}" == "" ]] ; then
 	# Ease the starting of a program using flexmalloc through GDB debugger
 	if test -n "${FLEXMALLOC_GDB}"
 	then
-		tmp_gdb=`mktemp /tmp/flexmalloc_gdb_cmd_file.XXXXXX`
+		tmp_gdb=`mktemp "${TMPDIR}"/flexmalloc_gdb_cmd_file.XXXXXX`
 		cat >$tmp_gdb <<EOF
 set environment FLEXMALLOC_DEFINITIONS ${1}
 set environment FLEXMALLOC_LOCATIONS ${2}

--- a/scripts/flexmalloc.sh
+++ b/scripts/flexmalloc.sh
@@ -26,6 +26,9 @@ fi
 export FLEXMALLOC_DEFINITIONS=${1}
 export FLEXMALLOC_LOCATIONS=${2}
 
+set_LD_PRELOAD="LD_PRELOAD=${FLEXMALLOC_HOME}/lib/${library}.so"
+runner="env ${set_LD_PRELOAD}"
+
 mpi_rank="${PMIX_RANK}"
 if [[ -z "${mpi_rank}" ]]; then
 	mpi_rank="${PMI_RANK}"
@@ -37,10 +40,27 @@ if [[ "${mpi_rank}" == "0" || "${mpi_rank}" == "" ]] ; then
 	if [[ "${FLEXMALLOC_VERBOSE}" == "" ]] ; then
 		export FLEXMALLOC_VERBOSE=1
 	fi
-	LD_PRELOAD=${FLEXMALLOC_HOME}/lib/${library}.so ${@:3}
-else 
+	# Ease the starting of a program using flexmalloc through GDB debugger
+	if test -n "${FLEXMALLOC_GDB}"
+	then
+		tmp_gdb=`mktemp /tmp/flexmalloc_gdb_cmd_file.XXXXXX`
+		cat >$tmp_gdb <<EOF
+set environment FLEXMALLOC_DEFINITIONS ${1}
+set environment FLEXMALLOC_LOCATIONS ${2}
+set exec-wrapper env '${set_LD_PRELOAD}'
+break main
+EOF
+		case "${FLEXMALLOC_GDB}" in
+			1|enabled|yes)
+				runner="gdb -x ${tmp_gdb} --args"
+				;;
+		esac
+	fi
+	# Start the application
+	${runner} ${@:3}
+else
 	export FLEXMALLOC_DEBUG=no
 	export FLEXMALLOC_VERBOSE=0
-	LD_PRELOAD=${FLEXMALLOC_HOME}/lib/${library}.so ${@:3} > /dev/null 2> /dev/null
+	${runner} ${@:3} > /dev/null 2> /dev/null
 fi
 


### PR DESCRIPTION
I updated the script such that you can easily start an application using flexmalloc with GDB.

You only need to set FLEXMALLOC_GDB to either `1`, `enable` or `yes` in your environment. It is only activated for either rank 0 (in a MPI environment) or for non-MPI applications. It is also very useful for debugging the library, as the LD_PRELOAD is only applied to the wrapped application and not to GDB.