### PR TITLE
Performance optimization of offset->address translation

### DIFF
--- a/src/allocator-memkind-pmem.cxx
+++ b/src/allocator-memkind-pmem.cxx
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <new>
+#include <algorithm>
 
 #include "flex-malloc.hxx"
 
@@ -229,12 +230,13 @@ void AllocatorMemkindPMEM::configure (const char *config)
 #warning This casting is necessary for gcc 7.3.1/fedora 27
 	for (char *tmp = strchr ((char*)config, '@');
 			tmp != nullptr && nnodes < _num_NUMA_nodes;
-			tmp = strchr (tmp+1, '@'))
+			tmp = strchr (tmp, '@'))
 	{
 		bool has_path = false;
 		char path[PATH_MAX] = {0};
 		{
 			// Copy into path the given path for PMEM -- skip every empty char after @
+			tmp++;
 			constexpr char blankchars[] = " \n\r\t\f\v";
 			size_t count = strspn(tmp, blankchars); // skip blank chars
 			const char* in = &tmp[count];

--- a/src/malloc-interposer.cxx
+++ b/src/malloc-interposer.cxx
@@ -220,20 +220,14 @@ void* dlopen(const char *file, int mode)
 	static void* (*o_dlopen) ( const char *file, int mode )=0;
 	o_dlopen = (void*(*)(const char *file, int mode)) dlsym(RTLD_NEXT,"dlopen");
 	void* res = (*o_dlopen)( file, mode );
-	char *env = getenv(TOOL_LOCATIONS_FILE);
 
-	if (LIKELY(malloc_interposer_started))
+	if (LIKELY(malloc_interposer_started) && !options.sourceFrames())
 	{
 		if (file != NULL)
 		{
-			if (env != nullptr)
-			{
-				VERBOSE_MSG(0, "New library '%s' was loaded. Updating code locations.\n", file);
-				codelocations->readfile(env, fallback->name());
-			}
+			codelocations->translate_pending_frames(file);
 		}
 	}
-
 	return res;
 }
 


### PR DESCRIPTION
Refactored translation code to avoid duplicated work, mainly:
- /proc/self/maps contents are cached and reused
- Library load events will only trigger translation if the new library appears in some callstack frame of the locations input file
